### PR TITLE
.npmrc: remove unused, readonly token

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,11 +1,11 @@
-/* eslint-disable no-undef */
 module.exports = {
   extends: [
-    '@gameflow-tv/eslint-config',
     'plugin:jest/recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:jsx-a11y/recommended',
+    '@gameflow-tv/eslint-config',
   ],
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'import', 'jsx-a11y'],
   parser: '@typescript-eslint/parser',
   env: {
     browser: true,

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 @gameflow-tv:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=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

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@gameflow-tv:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "autoprefixer": "^10.4.8",
         "esbuild": "^0.15.2",
         "eslint": "^8.21.0",
+        "eslint-plugin-prettier": "^4.2.1",
         "jest": "^28.1.3",
         "postcss": "^8.4.16",
         "postcss-cli": "^10.0.0",
@@ -5231,6 +5232,27 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.30.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
@@ -5526,6 +5548,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -8023,6 +8051,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -13175,6 +13215,15 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.30.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz",
@@ -13375,6 +13424,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -15168,6 +15223,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "28.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "autoprefixer": "^10.4.8",
         "esbuild": "^0.15.2",
         "eslint": "^8.21.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-jsx-a11y": "^6.6.1",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^28.1.3",
         "postcss": "^8.4.16",
@@ -2099,7 +2101,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2112,7 +2113,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.9.tgz",
       "integrity": "sha512-qZEWeccZCrHA2Au4/X05QW5CMdm4VjUDCrGq5gf1ZDcM4hRqreKrtwAn7yci9zfgAS9apvnsFXiGBHBAxZdK9A==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "core-js-pure": "^3.20.2",
         "regenerator-runtime": "^0.13.4"
@@ -3334,7 +3334,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
       "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.10.2",
         "@babel/runtime-corejs3": "^7.10.2"
@@ -3429,8 +3428,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/autoprefixer": {
       "version": "10.4.8",
@@ -3470,7 +3468,6 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -3479,8 +3476,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "28.1.3",
@@ -4050,7 +4046,6 @@
       "integrity": "sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw==",
       "dev": true,
       "hasInstallScript": true,
-      "optional": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -4109,8 +4104,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4274,8 +4268,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -5142,7 +5135,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
       "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.18.9",
         "aria-query": "^4.2.2",
@@ -5170,7 +5162,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7062,7 +7053,6 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
       "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.2"
@@ -7084,15 +7074,13 @@
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
       "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/language-tags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
       "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "language-subtag-registry": "~0.3.2"
       }
@@ -8250,8 +8238,7 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -10937,7 +10924,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
       "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -10947,7 +10933,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.9.tgz",
       "integrity": "sha512-qZEWeccZCrHA2Au4/X05QW5CMdm4VjUDCrGq5gf1ZDcM4hRqreKrtwAn7yci9zfgAS9apvnsFXiGBHBAxZdK9A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "core-js-pure": "^3.20.2",
         "regenerator-runtime": "^0.13.4"
@@ -11874,7 +11859,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
       "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@babel/runtime": "^7.10.2",
         "@babel/runtime-corejs3": "^7.10.2"
@@ -11947,8 +11931,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.4.8",
@@ -11968,15 +11951,13 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "babel-jest": {
       "version": "28.1.3",
@@ -12412,8 +12393,7 @@
       "version": "3.23.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.5.tgz",
       "integrity": "sha512-8t78LdpKSuCq4pJYCYk8hl7XEkAX+BP16yRIwL3AanTksxuEf7CM83vRyctmiEL8NDZ3jpUcv56fk9/zG3aIuw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -12456,8 +12436,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",
@@ -12577,8 +12556,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -13148,7 +13126,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
       "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@babel/runtime": "^7.18.9",
         "aria-query": "^4.2.2",
@@ -13169,8 +13146,7 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -14543,7 +14519,6 @@
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
       "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
       "dev": true,
-      "optional": true,
       "requires": {
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.2"
@@ -14559,15 +14534,13 @@
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
       "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "language-tags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
       "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "language-subtag-registry": "~0.3.2"
       }
@@ -15370,8 +15343,7 @@
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "license": "UNLICENSED",
       "devDependencies": {
-        "@gameflow-tv/eslint-config": "^0.0.8",
-        "@gameflow-tv/prettier-config": "^0.2.1",
+        "@gameflow-tv/eslint-config": "^0.1.4",
+        "@gameflow-tv/prettier-config": "^0.2.4",
         "@types/jest": "^28.1.6",
         "@types/node": "^18.6.3",
         "@types/react": "^18.0.15",
@@ -2238,19 +2238,13 @@
       }
     },
     "node_modules/@gameflow-tv/eslint-config": {
-      "version": "0.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@gameflow-tv/eslint-config/0.0.8/378e46865ad978c9ef8bbdff6122defe7d78c3c276d4b6497f06e23eed7f9f8d",
-      "integrity": "sha512-pGY7tSx9drNQc1y4J03XAb8zTRSoeuCHa1S65k/5r/Ca5N3EbyeGr9M0vbulR5U8/0Q1CHB28qkqIma4/QirIw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@gameflow-tv/eslint-config/-/eslint-config-0.1.4.tgz",
+      "integrity": "sha512-SbGmOJGbCa2/IB6o31V4dCErua68HWCEPuZ30NuJLFJ0Ff5rv9u26tFj8UCqQD55TWXhKnp+85Kp3vfJNROAwg==",
       "dev": true,
-      "license": "UNLICENSED",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.26.0",
-        "@typescript-eslint/parser": "^5.26.0",
-        "eslint-plugin-import": "^2.26.0"
-      },
       "optionalDependencies": {
         "eslint-config-react-app": ">= 7",
-        "eslint-plugin-compat": ">= 3",
+        "eslint-plugin-compat": ">= 4",
         "eslint-plugin-jest": ">= 26",
         "eslint-plugin-jsx-a11y": ">= 6",
         "eslint-plugin-node": ">=11",
@@ -2258,15 +2252,18 @@
         "eslint-plugin-react-hooks": ">= 4"
       },
       "peerDependencies": {
-        "eslint": ">= 8"
+        "@typescript-eslint/eslint-plugin": ">=5",
+        "@typescript-eslint/parser": ">=5",
+        "eslint": ">= 8",
+        "eslint-config-prettier": ">=8",
+        "eslint-plugin-import": ">=2"
       }
     },
     "node_modules/@gameflow-tv/prettier-config": {
-      "version": "0.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@gameflow-tv/prettier-config/0.2.1/73e8eb86440aaeb67749dd47c13d240f1b7d9ced7dc67692228421fa6aee71b9",
-      "integrity": "sha512-R5NYO1ykq90uk4BBhnJIgoTnR/YVEFjnRX3FkWyN+F6nL+SRhLt8F8/MPmERBZv1dYmvBlQ7V7QyeWrboOQHNw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@gameflow-tv/prettier-config/-/prettier-config-0.2.4.tgz",
+      "integrity": "sha512-LdHNaH9QXyB7JauBve/7YhHxksZEXt4MIzrhskTW8VNXBhTr9U6Mxl2bC66ssoR/mRLiYyuuITv3lzsqkH5krA==",
       "dev": true,
-      "license": "UNLICENSED",
       "peerDependencies": {
         "prettier": ">= 2"
       }
@@ -4788,6 +4785,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-react-app": {
@@ -10989,16 +10999,13 @@
       }
     },
     "@gameflow-tv/eslint-config": {
-      "version": "0.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@gameflow-tv/eslint-config/0.0.8/378e46865ad978c9ef8bbdff6122defe7d78c3c276d4b6497f06e23eed7f9f8d",
-      "integrity": "sha512-pGY7tSx9drNQc1y4J03XAb8zTRSoeuCHa1S65k/5r/Ca5N3EbyeGr9M0vbulR5U8/0Q1CHB28qkqIma4/QirIw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@gameflow-tv/eslint-config/-/eslint-config-0.1.4.tgz",
+      "integrity": "sha512-SbGmOJGbCa2/IB6o31V4dCErua68HWCEPuZ30NuJLFJ0Ff5rv9u26tFj8UCqQD55TWXhKnp+85Kp3vfJNROAwg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/eslint-plugin": "^5.26.0",
-        "@typescript-eslint/parser": "^5.26.0",
         "eslint-config-react-app": ">= 7",
-        "eslint-plugin-compat": ">= 3",
-        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-compat": ">= 4",
         "eslint-plugin-jest": ">= 26",
         "eslint-plugin-jsx-a11y": ">= 6",
         "eslint-plugin-node": ">=11",
@@ -11007,9 +11014,9 @@
       }
     },
     "@gameflow-tv/prettier-config": {
-      "version": "0.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@gameflow-tv/prettier-config/0.2.1/73e8eb86440aaeb67749dd47c13d240f1b7d9ced7dc67692228421fa6aee71b9",
-      "integrity": "sha512-R5NYO1ykq90uk4BBhnJIgoTnR/YVEFjnRX3FkWyN+F6nL+SRhLt8F8/MPmERBZv1dYmvBlQ7V7QyeWrboOQHNw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@gameflow-tv/prettier-config/-/prettier-config-0.2.4.tgz",
+      "integrity": "sha512-LdHNaH9QXyB7JauBve/7YhHxksZEXt4MIzrhskTW8VNXBhTr9U6Mxl2bC66ssoR/mRLiYyuuITv3lzsqkH5krA==",
       "dev": true,
       "requires": {}
     },
@@ -12840,6 +12847,14 @@
           }
         }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10961,7 +10961,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@esbuild/linux-loong64": {
       "version": "0.15.2",
@@ -11009,7 +11010,8 @@
       "version": "0.2.1",
       "resolved": "https://npm.pkg.github.com/download/@gameflow-tv/prettier-config/0.2.1/73e8eb86440aaeb67749dd47c13d240f1b7d9ced7dc67692228421fa6aee71b9",
       "integrity": "sha512-R5NYO1ykq90uk4BBhnJIgoTnR/YVEFjnRX3FkWyN+F6nL+SRhLt8F8/MPmERBZv1dYmvBlQ7V7QyeWrboOQHNw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -11720,7 +11722,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -13216,7 +13219,8 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.5.1",
@@ -14192,7 +14196,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "28.0.2",

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "build:styles": "postcss ./src/react/tailwind.source.css -o ./src/react/tailwind.css"
   },
   "devDependencies": {
-    "@gameflow-tv/eslint-config": "^0.0.8",
-    "@gameflow-tv/prettier-config": "^0.2.1",
+    "@gameflow-tv/eslint-config": "^0.1.4",
+    "@gameflow-tv/prettier-config": "^0.2.4",
     "@types/jest": "^28.1.6",
     "@types/node": "^18.6.3",
     "@types/react": "^18.0.15",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "autoprefixer": "^10.4.8",
     "esbuild": "^0.15.2",
     "eslint": "^8.21.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "jest": "^28.1.3",
     "postcss": "^8.4.16",
     "postcss-cli": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "autoprefixer": "^10.4.8",
     "esbuild": "^0.15.2",
     "eslint": "^8.21.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^28.1.3",
     "postcss": "^8.4.16",

--- a/src/tailwind/helpers.test.ts
+++ b/src/tailwind/helpers.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import { fallback } from '../foundation'
 import { keysToKebab, omit, shortenKeys } from './helpers'
 


### PR DESCRIPTION
GitHub disables any public access tokens, which it just did for ours even though it's read-only. Turns out, we don't even need it.